### PR TITLE
make from_email argument optional in send_mail

### DIFF
--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -35,7 +35,7 @@ def get_connection(backend=None, fail_silently=False, **kwds):
     return klass(fail_silently=fail_silently, **kwds)
 
 
-def send_mail(subject, message, from_email, recipient_list,
+def send_mail(subject, message, recipient_list, from_email=None,
               fail_silently=False, auth_user=None, auth_password=None,
               connection=None, html_message=None):
     """


### PR DESCRIPTION
the django docs state that, while sending mail, if no from_email is passed, it will use the `DEFAULT_FROM_EMAIL`.
source: https://docs.djangoproject.com/en/3.1/topics/email/

However, when using the send_mail function, the `from_email` argument is not optional.
resolves https://code.djangoproject.com/ticket/32633#ticket
giving a default value of `None` to it will resolve this issue.